### PR TITLE
- Fix MONO sound for channel 2

### DIFF
--- a/cores/mist/YM2149_volmix.vhd
+++ b/cores/mist/YM2149_volmix.vhd
@@ -529,7 +529,7 @@ begin
             vol_table_in_r(11 downto 8) <= reg(10)(3 downto 0);
           else
             vol_table_in_l(11 downto 8) <= env_vol(4 downto 1);
-            vol_table_in_r(11 downto 8) <= reg(10)(3 downto 0);
+            vol_table_in_r(11 downto 8) <= env_vol(4 downto 1);
           end if;
         end if;
       end if;


### PR DESCRIPTION
In 2013 I introduced a bug in the YM code when I implemented the stereo sound.

It only affects the envelope in mono in the channel 2 (or C)

Here is the fix.
