### PR TITLE
[C16] fix csync signal for better composite video

### DIFF
--- a/cores/c16/ted.v
+++ b/cores/c16/ted.v
@@ -1164,7 +1164,7 @@ assign VBLANK_STOP = pal?9'd269:9'd244;		// Screen blanking stop// Composite Syn
 
 always @(posedge clk)								// composite synchron is either hsync or equalization+vsync
 	begin
-	csyncreg<=(equalization)?(eq1&eq2)^vsync:hsync;
+	csyncreg<=(equalization)?~((eq1&eq2)|~vsync):hsync;
 	end
 
 always @(posedge clk)								// vsync signal inverts equalization signal


### PR DESCRIPTION
This PR fixes a problem in C16 when `csync` is used to generate a composite video signal via the AD724 converter chip (e.g. on the Mistica board). The resulting image is either monochrome or with wrong colors.

Apparently the AD724, and presumably other video devices, needs `vsync` and `hsync` to be perfectly aligned in time; but currently it's not due to the way `csync` is generated:
```
csync = (eq1&eq2)^vsync
```
At the very start of the vertical sync `(eq1&eq2)` is 1, `vsync` is also 1 and the xor makes the resulting `csync` 0, when it actually should be 1.

The solution is to create a `csync` signal with: 
```
csync = ~((eq1&eq2)|~vsync)
```

The same issue is on the VIC-20 core, which is currently addressed in [this PR](https://github.com/gyurco/VIC20_MiST/pull/6)
